### PR TITLE
Improve null check for current breadcrumb retrieval

### DIFF
--- a/src/Breadcrumb/Breadcrumbs.php
+++ b/src/Breadcrumb/Breadcrumbs.php
@@ -31,7 +31,13 @@ final class Breadcrumbs
 
     private function getCurrentBreadcrumb(AdminContext $context): ?BreadcrumbInterface
     {
-        $breadcrumbType = BreadcrumbType::tryFrom($context->getCrud()?->getCurrentPage());
+        $crud = $context->getCrud();
+
+        if (null === $crud) {
+            return null;
+        }
+        
+        $breadcrumbType = BreadcrumbType::tryFrom($crud->getCurrentPage());
 
         if (null === $breadcrumbType) {
             return null;


### PR DESCRIPTION
Refactor getCurrentBreadcrumb to check for null crud before accessing current page.

Background: old implementation throws deprecations under PHP 8.2.
Alshenetsky\EasyAdminBreadcrumbs\Breadcrumb\BreadcrumbType::tryFrom(): Passing null to parameter #1 ($value) of type string|int is deprecated